### PR TITLE
Add support for activesupport 7.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    uk_academic_calendar (1.0.0)
+    uk_academic_calendar (1.0.1)
       abstract_class (~> 1.0)
-      activesupport (~> 6.1)
+      activesupport (>= 6.1, < 8.x)
       easter (~> 0.2)
       sorted_set (~> 1.0)
 

--- a/lib/uk_academic_calendar/version.rb
+++ b/lib/uk_academic_calendar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UKAcademicCalendar
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/uk_academic_calendar.gemspec
+++ b/uk_academic_calendar.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'abstract_class', '~> 1.0'
-  spec.add_dependency 'activesupport', '~> 6.1'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 8.x'
   spec.add_dependency 'easter', '~> 0.2'
   spec.add_dependency 'sorted_set', '~> 1.0'
 end


### PR DESCRIPTION
This PR adds support for `activesupport` 7.x so this gem can be used in rails 7 projects.