### PR TITLE
Update active support dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     uk_academic_calendar (1.1.0)
       abstract_class (~> 1.0)
-      activesupport (~> 7.0)
+      activesupport (>= 7.0)
       easter (~> 0.2)
       sorted_set (~> 1.0)
 

--- a/uk_academic_calendar.gemspec
+++ b/uk_academic_calendar.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'abstract_class', '~> 1.0'
-  spec.add_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'activesupport', '>= 7.0'
   spec.add_dependency 'easter', '~> 0.2'
   spec.add_dependency 'sorted_set', '~> 1.0'
 end


### PR DESCRIPTION
This PR tweaks the dependency on `activesupport` so this gem can be used in projects depending on versions > 7